### PR TITLE
Update workflows to reference Shadow Scroll Blossom

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,29 +2,41 @@ name: Deploy
 
 on:
   push:
-    branches: [ main ]
-  workflow_dispatch:
+    branches: [main]
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
       - run: npm ci
       - run: npm run build
-        env:
-          GITHUB_PAGES: 'true'
-      - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/configure-pages@v5
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,32 +1,59 @@
+---
 name: Preview
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
-  pull-requests: write
   pages: write
   id-token: write
+  pull-requests: write
+
+concurrency:
+  group: pages-preview-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
-  preview:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
       - run: npm ci
       - run: npm run build
-        env:
-          GITHUB_PAGES: 'true'
-      - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      pull-requests: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/configure-pages@v5
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v4
         with:
           preview: true
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Live preview: ${{ steps.deployment.outputs.page_url }}`
+            })

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-# Welcome to your Lovable project
+# Rust Terminal Forge
+
+Rust Terminal Forge is a secure web-based terminal emulator built with React, TypeScript and Tailwind CSS. The project reuses the deployment approach from [Shadow Scroll Blossom](https://github.com/BA-CalderonMorales/shadow-scroll-blossom) to automatically publish the `dist` folder to GitHub Pages using GitHub Actions.
+
+## Getting Started
+
+Install the dependencies and start the development server:
+
+```sh
+npm install
+npm run dev
+```
+
+Create a production build with:
+
+```sh
+npm run build
+```
 
 ## Project info
 
@@ -24,16 +41,16 @@ Follow these steps:
 
 ```sh
 # Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
+ git clone <YOUR_GIT_URL>
 
 # Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
+ cd <YOUR_PROJECT_NAME>
 
 # Step 3: Install the necessary dependencies.
-npm i
+ npm i
 
 # Step 4: Start the development server with auto-reloading and an instant preview.
-npm run dev
+ npm run dev
 ```
 
 **Edit a file directly in GitHub**
@@ -60,16 +77,9 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
-## How can I deploy this project?
+## Deployment
 
-Simply open [Lovable](https://lovable.dev/projects/8625de05-3749-4001-aedf-b432dd29c710) and click on Share -> Publish.
-
-## GitHub Pages
-
-This repository is configured to publish the site using GitHub Pages.
-
-- `.github/workflows/preview.yml` builds a preview for every pull request and posts the URL as a comment.
-- `.github/workflows/deploy.yml` deploys the `main` branch to GitHub Pages.
+Pushes to `main` automatically deploy to **GitHub Pages** via `.github/workflows/deploy.yml`. Pull requests generate live previews using `.github/workflows/preview.yml`.
 
 Once deployed, your site will be available at `https://<OWNER>.github.io/rust-terminal-forge/`.
 


### PR DESCRIPTION
## Summary
- reuse the GitHub Pages workflow from Shadow Scroll Blossom
- add PR preview workflow based on Shadow Scroll Blossom
- update the README with instructions and reference to the source repo

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843b0aac3648333b04fb83118db2d22