### PR TITLE
Fix pages deploy and update README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+        env:
+          GITHUB_PAGES: 'true'
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,6 +27,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+        env:
+          GITHUB_PAGES: 'true'
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rust Terminal Forge
 
-Rust Terminal Forge is a secure web-based terminal emulator built with React, TypeScript and Tailwind CSS. The project reuses the deployment approach from [Shadow Scroll Blossom](https://github.com/BA-CalderonMorales/shadow-scroll-blossom) to automatically publish the `dist` folder to GitHub Pages using GitHub Actions.
+Rust Terminal Forge is a secure web-based terminal emulator built with React, TypeScript and Tailwind CSS. It automatically publishes the `dist` folder to GitHub Pages using GitHub Actions for both production deploys and preview environments.
 
 <details>
 <summary><strong>Getting Started</strong></summary>


### PR DESCRIPTION
## Summary
- ensure GitHub Pages build uses the correct base path
- update project introduction in README

## Testing
- `GITHUB_PAGES=true npm run build`
- `npm run lint` *(fails: react-refresh only-export-components, @typescript-eslint/no-empty-object-type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6843ddce4b94833384f1415ba70d7840