### PR TITLE
Fix pages deployment base path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
       - run: npm run build
         env:
           GITHUB_PAGES: 'true'
+          VITE_BASE: '/rust-terminal-forge/'
+      - run: cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,6 +29,8 @@ jobs:
       - run: npm run build
         env:
           GITHUB_PAGES: 'true'
+          VITE_BASE: '/rust-terminal-forge/'
+      - run: cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,11 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
+const basePath = process.env.VITE_BASE ||
+  (process.env.GITHUB_PAGES === 'true' ? '/rust-terminal-forge/' : '/');
+
 export default defineConfig(({ mode }) => ({
-  base: process.env.GITHUB_PAGES === 'true' ? '/rust-terminal-forge/' : '/',
+  base: basePath,
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- ensure Vite uses a configurable base path
- set `VITE_BASE` and create `404.html` in deploy workflows

## Testing
- `npm run lint` *(fails: no-empty-object-type, no-control-regex, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6843e29caffc8333ab28d41eba366577