### PR TITLE
Fix base path routing for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,6 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
-        env:
-          GITHUB_PAGES: 'true'
-          VITE_BASE: '/rust-terminal-forge/'
       - run: cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,9 +27,6 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
-        env:
-          GITHUB_PAGES: 'true'
-          VITE_BASE: '/rust-terminal-forge/'
       - run: cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,11 +4,9 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-const basePath = process.env.VITE_BASE ||
-  (process.env.GITHUB_PAGES === 'true' ? '/rust-terminal-forge/' : '/');
 
 export default defineConfig(({ mode }) => ({
-  base: basePath,
+  base: mode === 'development' ? '/' : '/rust-terminal-forge/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- set the production base path directly in `vite.config.ts`
- pass the base URL to `BrowserRouter`
- simplify deploy and preview workflows

## Testing
- `npm run build`
- `npm run lint` *(fails: `no-empty-object-type`, `no-explicit-any`, `no-useless-escape`, `no-control-regex` and `no-require-imports`)*

------
https://chatgpt.com/codex/tasks/task_e_6843f24727cc8333ad9f14be787c84cb