### PR TITLE
Add basic Vim command

### DIFF
--- a/src/core/SecureCommandProcessor.ts
+++ b/src/core/SecureCommandProcessor.ts
@@ -71,6 +71,8 @@ export class SecureCommandProcessor {
           return this.fileSystemCommands.handleFind(args, id, command, timestamp);
         case 'grep':
           return this.fileSystemCommands.handleGrep(args, id, command, timestamp);
+        case 'vim':
+          return this.fileSystemCommands.handleVim(args, id, command, timestamp);
         case 'echo':
           return this.systemCommands.handleEcho(args, id, command, timestamp);
         case 'whoami':
@@ -130,7 +132,7 @@ export class SecureCommandProcessor {
   }
 
   private suggestCommand(command: string): string {
-    const commands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'find', 'grep', 'echo', 'whoami', 'date', 'env', 'which', 'history', 'alias', 'cargo', 'clear', 'help'];
+    const commands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'find', 'grep', 'vim', 'echo', 'whoami', 'date', 'env', 'which', 'history', 'alias', 'cargo', 'clear', 'help'];
     const suggestions = commands.filter(cmd => 
       cmd.includes(command) || 
       this.levenshteinDistance(cmd, command) <= 2

--- a/src/core/commands/BaseCommandHandler.ts
+++ b/src/core/commands/BaseCommandHandler.ts
@@ -48,7 +48,7 @@ export abstract class BaseCommandHandler {
   }
 
   protected suggestCommand(command: string): string {
-    const commands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'find', 'grep', 'echo', 'whoami', 'date', 'env', 'which', 'history', 'alias', 'cargo', 'clear', 'help'];
+    const commands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'find', 'grep', 'vim', 'echo', 'whoami', 'date', 'env', 'which', 'history', 'alias', 'cargo', 'clear', 'help'];
     const suggestions = commands.filter(cmd => 
       cmd.includes(command) || 
       this.levenshteinDistance(cmd, command) <= 2

--- a/src/core/commands/FileSystemCommands.ts
+++ b/src/core/commands/FileSystemCommands.ts
@@ -10,6 +10,7 @@ import { TouchCommand } from './filesystem/TouchCommand';
 import { CatCommand } from './filesystem/CatCommand';
 import { FindCommand } from './filesystem/FindCommand';
 import { GrepCommand } from './filesystem/GrepCommand';
+import { VimCommand } from './filesystem/VimCommand';
 
 export class FileSystemCommands extends BaseCommandHandler {
   private pwdCommand: PwdCommand;
@@ -20,6 +21,7 @@ export class FileSystemCommands extends BaseCommandHandler {
   private catCommand: CatCommand;
   private findCommand: FindCommand;
   private grepCommand: GrepCommand;
+  private vimCommand: VimCommand;
 
   constructor(private fileSystemManager: FileSystemManager) {
     super();
@@ -31,6 +33,7 @@ export class FileSystemCommands extends BaseCommandHandler {
     this.catCommand = new CatCommand(fileSystemManager);
     this.findCommand = new FindCommand(fileSystemManager);
     this.grepCommand = new GrepCommand(fileSystemManager);
+    this.vimCommand = new VimCommand(fileSystemManager);
   }
 
   handlePwd(id: string, command: string, timestamp: string): TerminalCommand {
@@ -63,5 +66,9 @@ export class FileSystemCommands extends BaseCommandHandler {
 
   handleGrep(args: string[], id: string, command: string, timestamp: string): TerminalCommand {
     return this.grepCommand.handle(args, id, command, timestamp);
+  }
+
+  handleVim(args: string[], id: string, command: string, timestamp: string): TerminalCommand {
+    return this.vimCommand.handle(args, id, command, timestamp);
   }
 }

--- a/src/core/commands/UtilityCommands.ts
+++ b/src/core/commands/UtilityCommands.ts
@@ -71,6 +71,7 @@ export class UtilityCommands extends BaseCommandHandler {
   mkdir      - Create directory
   touch      - Create or update file
   cat        - Display file contents
+  vim <file> - View file in read-only mode
   echo       - Display text
   whoami     - Show current user
   date       - Show current date and time

--- a/src/core/commands/filesystem/VimCommand.ts
+++ b/src/core/commands/filesystem/VimCommand.ts
@@ -1,0 +1,38 @@
+import { TerminalCommand } from '../../types';
+import { BaseCommandHandler } from '../BaseCommandHandler';
+import { FileSystemManager } from '../../filesystem/FileSystemManager';
+
+export class VimCommand extends BaseCommandHandler {
+  constructor(private fileSystemManager: FileSystemManager) {
+    super();
+  }
+
+  handle(args: string[], id: string, command: string, timestamp: string): TerminalCommand {
+    if (args.length === 0) {
+      return this.generateCommand(id, command, 'vim: missing file operand', timestamp, 1);
+    }
+
+    const fileName = args[0];
+    const currentContents = this.fileSystemManager.getDirectoryContents(this.fileSystemManager.getCurrentPath());
+    const file = currentContents?.find(item => item.name === fileName && item.type === 'file');
+
+    if (!file) {
+      return this.generateCommand(id, command, `vim: ${fileName}: No such file or directory`, timestamp, 1);
+    }
+
+    let content = '';
+    if (fileName.endsWith('.rs')) {
+      content = `fn main() {\n    println!("Hello, world!");\n}`;
+    } else if (fileName.endsWith('.toml')) {
+      content = `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`;
+    } else if (fileName.endsWith('.md')) {
+      content = `# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.`;
+    } else {
+      content = `Content of ${fileName}`;
+    }
+
+    const lines = content.split('\n').map((line, idx) => `${(idx + 1).toString().padStart(4)} ${line}`);
+    const output = `Vim (read-only): ${fileName}\n${lines.join('\n')}`;
+    return this.generateCommand(id, command, output, timestamp);
+  }
+}

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -62,6 +62,12 @@ describe('filesystem commands', () => {
     const res = fsCmds.handleGrep(['Hello', 'main.rs'], '1', 'grep Hello main.rs', ts);
     expect(res.output).toContain('Hello');
   });
+
+  it('vim displays file with line numbers', () => {
+    fsCmds.handleCd(['../documents'], '1', 'cd ../documents', ts);
+    const res = fsCmds.handleVim(['notes.txt'], '1', 'vim notes.txt', ts);
+    expect(res.output).toContain('Vim (read-only): notes.txt');
+  });
 });
 
 describe('system commands', () => {


### PR DESCRIPTION
## Summary
- implement a simple `vim` command
- wire up `vim` in the filesystem command handler
- update help and command suggestions
- cover `vim` usage in tests

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471b5d2dec8333a4267061bd336a96