### PR TITLE
Add simple text editor

### DIFF
--- a/src/core/SecureCommandProcessor.ts
+++ b/src/core/SecureCommandProcessor.ts
@@ -71,6 +71,8 @@ export class SecureCommandProcessor {
           return this.fileSystemCommands.handleFind(args, id, command, timestamp);
         case 'grep':
           return this.fileSystemCommands.handleGrep(args, id, command, timestamp);
+        case 'edit':
+          return this.fileSystemCommands.handleEdit(args, id, command, timestamp);
         case 'vim':
           return this.fileSystemCommands.handleVim(args, id, command, timestamp);
         case 'echo':
@@ -167,5 +169,13 @@ export class SecureCommandProcessor {
 
   getFileSystem() {
     return this.fileSystemManager.getFileSystem();
+  }
+
+  readFile(fileName: string): string | null {
+    return this.fileSystemManager.getFileContent(this.getCurrentPath(), fileName);
+  }
+
+  writeFile(fileName: string, content: string): void {
+    this.fileSystemManager.setFileContent(this.getCurrentPath(), fileName, content);
   }
 }

--- a/src/core/commands/FileSystemCommands.ts
+++ b/src/core/commands/FileSystemCommands.ts
@@ -11,6 +11,7 @@ import { CatCommand } from './filesystem/CatCommand';
 import { FindCommand } from './filesystem/FindCommand';
 import { GrepCommand } from './filesystem/GrepCommand';
 import { VimCommand } from './filesystem/VimCommand';
+import { EditCommand } from './filesystem/EditCommand';
 
 export class FileSystemCommands extends BaseCommandHandler {
   private pwdCommand: PwdCommand;
@@ -22,6 +23,7 @@ export class FileSystemCommands extends BaseCommandHandler {
   private findCommand: FindCommand;
   private grepCommand: GrepCommand;
   private vimCommand: VimCommand;
+  private editCommand: EditCommand;
 
   constructor(private fileSystemManager: FileSystemManager) {
     super();
@@ -34,6 +36,7 @@ export class FileSystemCommands extends BaseCommandHandler {
     this.findCommand = new FindCommand(fileSystemManager);
     this.grepCommand = new GrepCommand(fileSystemManager);
     this.vimCommand = new VimCommand(fileSystemManager);
+    this.editCommand = new EditCommand(fileSystemManager);
   }
 
   handlePwd(id: string, command: string, timestamp: string): TerminalCommand {
@@ -70,5 +73,9 @@ export class FileSystemCommands extends BaseCommandHandler {
 
   handleVim(args: string[], id: string, command: string, timestamp: string): TerminalCommand {
     return this.vimCommand.handle(args, id, command, timestamp);
+  }
+
+  handleEdit(args: string[], id: string, command: string, timestamp: string): TerminalCommand {
+    return this.editCommand.handle(args, id, command, timestamp);
   }
 }

--- a/src/core/commands/UtilityCommands.ts
+++ b/src/core/commands/UtilityCommands.ts
@@ -71,6 +71,7 @@ export class UtilityCommands extends BaseCommandHandler {
   mkdir      - Create directory
   touch      - Create or update file
   cat        - Display file contents
+  edit <file> - Edit file in simple editor
   vim <file> - View file in read-only mode
   echo       - Display text
   whoami     - Show current user

--- a/src/core/commands/filesystem/CatCommand.ts
+++ b/src/core/commands/filesystem/CatCommand.ts
@@ -21,15 +21,21 @@ export class CatCommand extends BaseCommandHandler {
       return this.generateCommand(id, command, `cat: ${fileName}: No such file or directory`, timestamp, 1);
     }
 
-    let content = '';
-    if (fileName.endsWith('.rs')) {
-      content = `fn main() {\n    println!("Hello, world!");\n}`;
-    } else if (fileName.endsWith('.toml')) {
-      content = `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`;
-    } else if (fileName.endsWith('.md')) {
-      content = `# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.`;
-    } else {
-      content = `Content of ${fileName}`;
+    let content = this.fileSystemManager.getFileContent(
+      this.fileSystemManager.getCurrentPath(),
+      fileName
+    );
+
+    if (content === null) {
+      if (fileName.endsWith('.rs')) {
+        content = `fn main() {\n    println!("Hello, world!");\n}`;
+      } else if (fileName.endsWith('.toml')) {
+        content = `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`;
+      } else if (fileName.endsWith('.md')) {
+        content = `# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.`;
+      } else {
+        content = `Content of ${fileName}`;
+      }
     }
 
     return this.generateCommand(id, command, content, timestamp);

--- a/src/core/commands/filesystem/EditCommand.ts
+++ b/src/core/commands/filesystem/EditCommand.ts
@@ -1,0 +1,26 @@
+import { TerminalCommand } from '../../types';
+import { BaseCommandHandler } from '../BaseCommandHandler';
+import { FileSystemManager } from '../../filesystem/FileSystemManager';
+
+export class EditCommand extends BaseCommandHandler {
+  constructor(private fileSystemManager: FileSystemManager) {
+    super();
+  }
+
+  handle(args: string[], id: string, command: string, timestamp: string): TerminalCommand {
+    if (args.length === 0) {
+      return this.generateCommand(id, command, 'edit: missing file operand', timestamp, 1);
+    }
+
+    const fileName = args[0];
+    const currentContents = this.fileSystemManager.getDirectoryContents(this.fileSystemManager.getCurrentPath());
+    const file = currentContents?.find(item => item.name === fileName && item.type === 'file');
+
+    if (!file) {
+      return this.generateCommand(id, command, `edit: ${fileName}: No such file or directory`, timestamp, 1);
+    }
+
+    const output = `__OPEN_EDITOR__${fileName}`;
+    return this.generateCommand(id, command, output, timestamp);
+  }
+}

--- a/src/core/commands/filesystem/TouchCommand.ts
+++ b/src/core/commands/filesystem/TouchCommand.ts
@@ -25,7 +25,8 @@ export class TouchCommand extends BaseCommandHandler {
         name: fileName,
         size: 0,
         permissions: '-rw-r--r--',
-        lastModified: new Date().toISOString().slice(0, 16).replace('T', ' ')
+        lastModified: new Date().toISOString().slice(0, 16).replace('T', ' '),
+        content: ''
       });
     }
 

--- a/src/core/filesystem/FileSystemManager.ts
+++ b/src/core/filesystem/FileSystemManager.ts
@@ -5,6 +5,7 @@ interface FileSystemNode {
   size?: number;
   permissions: string;
   lastModified: string;
+  content?: string;
 }
 
 interface FileSystem {
@@ -31,24 +32,24 @@ export class FileSystemManager {
     '/home/user': [
       { type: 'directory', name: 'project', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:30' },
       { type: 'directory', name: 'documents', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 09:15' },
-      { type: 'file', name: '.bashrc', size: 1024, permissions: '-rw-r--r--', lastModified: '2024-01-10 14:20' }
+      { type: 'file', name: '.bashrc', size: 1024, permissions: '-rw-r--r--', lastModified: '2024-01-10 14:20', content: 'export PATH=/usr/bin:$PATH' }
     ],
     '/home/user/project': [
-      { type: 'file', name: 'Cargo.toml', size: 456, permissions: '-rw-r--r--', lastModified: '2024-01-15 10:30' },
+      { type: 'file', name: 'Cargo.toml', size: 456, permissions: '-rw-r--r--', lastModified: '2024-01-15 10:30', content: '[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"' },
       { type: 'directory', name: 'src', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:25' },
       { type: 'directory', name: 'target', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:28' },
-      { type: 'file', name: 'README.md', size: 2048, permissions: '-rw-r--r--', lastModified: '2024-01-15 09:45' }
+      { type: 'file', name: 'README.md', size: 2048, permissions: '-rw-r--r--', lastModified: '2024-01-15 09:45', content: '# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.' }
     ],
     '/home/user/project/src': [
-      { type: 'file', name: 'main.rs', size: 1536, permissions: '-rw-r--r--', lastModified: '2024-01-15 10:25' },
-      { type: 'file', name: 'lib.rs', size: 512, permissions: '-rw-r--r--', lastModified: '2024-01-15 09:30' }
+      { type: 'file', name: 'main.rs', size: 1536, permissions: '-rw-r--r--', lastModified: '2024-01-15 10:25', content: 'fn main() {\n    println!("Hello, world!");\n}' },
+      { type: 'file', name: 'lib.rs', size: 512, permissions: '-rw-r--r--', lastModified: '2024-01-15 09:30', content: '' }
     ],
     '/home/user/project/target': [
       { type: 'directory', name: 'debug', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:28' },
       { type: 'directory', name: 'release', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:00' }
     ],
     '/home/user/documents': [
-      { type: 'file', name: 'notes.txt', size: 1024, permissions: '-rw-r--r--', lastModified: '2024-01-14 16:20' }
+      { type: 'file', name: 'notes.txt', size: 1024, permissions: '-rw-r--r--', lastModified: '2024-01-14 16:20', content: 'These are some notes.' }
     ]
   };
 
@@ -145,6 +146,38 @@ export class FileSystemManager {
       if (file) {
         file.lastModified = new Date().toISOString().slice(0, 16).replace('T', ' ');
       }
+    }
+  }
+
+  getFileContent(path: string, fileName: string): string | null {
+    const contents = this.fileSystem[path];
+    const file = contents?.find(item => item.name === fileName && item.type === 'file');
+    if (file && 'content' in file) {
+      return file.content ?? '';
+    }
+    return null;
+  }
+
+  setFileContent(path: string, fileName: string, content: string): void {
+    if (!this.fileSystem[path]) {
+      this.fileSystem[path] = [];
+    }
+
+    let file = this.fileSystem[path].find(item => item.name === fileName && item.type === 'file');
+    if (!file) {
+      file = {
+        type: 'file',
+        name: fileName,
+        size: content.length,
+        permissions: '-rw-r--r--',
+        lastModified: new Date().toISOString().slice(0, 16).replace('T', ' '),
+        content
+      };
+      this.fileSystem[path].push(file);
+    } else {
+      file.content = content;
+      file.size = content.length;
+      file.lastModified = new Date().toISOString().slice(0, 16).replace('T', ' ');
     }
   }
 }

--- a/src/home/components/FileEditor.tsx
+++ b/src/home/components/FileEditor.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface FileEditorProps {
+  open: boolean;
+  fileName: string;
+  initialContent: string;
+  onSave: (content: string) => void;
+  onClose: () => void;
+}
+
+export const FileEditor: React.FC<FileEditorProps> = ({ open, fileName, initialContent, onSave, onClose }) => {
+  const [content, setContent] = useState(initialContent);
+
+  useEffect(() => {
+    if (open) {
+      setContent(initialContent);
+    }
+  }, [open, initialContent]);
+
+  const handleSave = () => {
+    onSave(content);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="w-[95vw] sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Editing {fileName}</DialogTitle>
+        </DialogHeader>
+        <textarea
+          className="w-full h-80 bg-black text-green-400 font-mono p-2 border border-green-700 outline-none"
+          value={content}
+          onChange={e => setContent(e.target.value)}
+        />
+        <DialogFooter>
+          <Button onClick={handleSave}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/home/components/Terminal.tsx
+++ b/src/home/components/Terminal.tsx
@@ -7,6 +7,7 @@ interface TerminalProps {
   session: TerminalSession;
   currentPath: string;
   onExecuteCommand: (command: string) => void;
+  onOpenEditor: (fileName: string) => void;
   username: string;
 }
 
@@ -14,6 +15,7 @@ export const Terminal: React.FC<TerminalProps> = ({
   session,
   currentPath,
   onExecuteCommand,
+  onOpenEditor,
   username
 }) => {
   const [currentInput, setCurrentInput] = useState('');
@@ -44,7 +46,16 @@ export const Terminal: React.FC<TerminalProps> = ({
     }
   }, [session.history]);
 
-  const visibleHistory = session.history.filter(cmd => cmd.output !== '__CLEAR__');
+  useEffect(() => {
+    const last = session.history[session.history.length - 1];
+    if (last && last.output.startsWith('__OPEN_EDITOR__')) {
+      onOpenEditor(last.output.replace('__OPEN_EDITOR__', ''));
+    }
+  }, [session.history, onOpenEditor]);
+
+  const visibleHistory = session.history.filter(
+    cmd => cmd.output !== '__CLEAR__' && !cmd.output.startsWith('__OPEN_EDITOR__')
+  );
   
   // Find last clear command index using reverse iteration
   let lastClearIndex = -1;

--- a/src/home/viewModel.ts
+++ b/src/home/viewModel.ts
@@ -47,9 +47,11 @@ export class HomeViewModel {
     this.notifyStateChange();
   }
 
-  executeCommand(input: string): void {
+  executeCommand(input: string): TerminalCommand {
     const activeSession = this.model.getActiveSession();
-    if (!activeSession) return;
+    if (!activeSession) {
+      throw new Error('No active session');
+    }
 
     try {
       // Pass session ID for rate limiting
@@ -63,6 +65,7 @@ export class HomeViewModel {
       }
       
       this.notifyStateChange();
+      return command;
     } catch (error) {
       SecurityUtils.logSecurityEvent('command_execution_error', { command: input, error });
       
@@ -77,6 +80,7 @@ export class HomeViewModel {
       
       this.model.addCommandToSession(activeSession.id, errorCommand);
       this.notifyStateChange();
+      return errorCommand;
     }
   }
 
@@ -119,5 +123,14 @@ export class HomeViewModel {
 
   getFileSystem() {
     return this.commandProcessor.getFileSystem();
+  }
+
+  readFile(fileName: string): string {
+    return this.commandProcessor.readFile(fileName) ?? '';
+  }
+
+  saveFile(fileName: string, content: string): void {
+    this.commandProcessor.writeFile(fileName, content);
+    this.notifyStateChange();
   }
 }

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -68,6 +68,12 @@ describe('filesystem commands', () => {
     const res = fsCmds.handleVim(['notes.txt'], '1', 'vim notes.txt', ts);
     expect(res.output).toContain('Vim (read-only): notes.txt');
   });
+
+  it('edit returns editor marker', () => {
+    fsCmds.handleCd(['../documents'], '1', 'cd ../documents', ts);
+    const res = fsCmds.handleEdit(['notes.txt'], '1', 'edit notes.txt', ts);
+    expect(res.output).toBe('__OPEN_EDITOR__notes.txt');
+  });
 });
 
 describe('system commands', () => {


### PR DESCRIPTION
## Summary
- extend file system nodes with `content`
- add read/write file utilities
- create `EditCommand` for launching a basic editor
- support editor command in command processor
- implement `FileEditor` dialog
- open editor when `edit` command is executed
- update tests for new command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68471f850500833388eebd86dc80482e