### PR TITLE
Add in-browser editor tabs

### DIFF
--- a/src/core/SecureCommandProcessor.ts
+++ b/src/core/SecureCommandProcessor.ts
@@ -168,4 +168,12 @@ export class SecureCommandProcessor {
   getFileSystem() {
     return this.fileSystemManager.getFileSystem();
   }
+
+  readFile(fileName: string): string {
+    return this.fileSystemManager.readFile(this.fileSystemManager.getCurrentPath(), fileName);
+  }
+
+  writeFile(fileName: string, content: string): void {
+    this.fileSystemManager.writeFile(this.fileSystemManager.getCurrentPath(), fileName, content);
+  }
 }

--- a/src/core/commands/filesystem/CatCommand.ts
+++ b/src/core/commands/filesystem/CatCommand.ts
@@ -21,16 +21,10 @@ export class CatCommand extends BaseCommandHandler {
       return this.generateCommand(id, command, `cat: ${fileName}: No such file or directory`, timestamp, 1);
     }
 
-    let content = '';
-    if (fileName.endsWith('.rs')) {
-      content = `fn main() {\n    println!("Hello, world!");\n}`;
-    } else if (fileName.endsWith('.toml')) {
-      content = `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`;
-    } else if (fileName.endsWith('.md')) {
-      content = `# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.`;
-    } else {
-      content = `Content of ${fileName}`;
-    }
+    const content = this.fileSystemManager.readFile(
+      this.fileSystemManager.getCurrentPath(),
+      fileName
+    );
 
     return this.generateCommand(id, command, content, timestamp);
   }

--- a/src/core/commands/filesystem/TouchCommand.ts
+++ b/src/core/commands/filesystem/TouchCommand.ts
@@ -27,6 +27,7 @@ export class TouchCommand extends BaseCommandHandler {
         permissions: '-rw-r--r--',
         lastModified: new Date().toISOString().slice(0, 16).replace('T', ' ')
       });
+      this.fileSystemManager.writeFile(this.fileSystemManager.getCurrentPath(), fileName, '');
     }
 
     return this.generateCommand(id, command, '', timestamp);

--- a/src/core/commands/filesystem/VimCommand.ts
+++ b/src/core/commands/filesystem/VimCommand.ts
@@ -20,19 +20,13 @@ export class VimCommand extends BaseCommandHandler {
       return this.generateCommand(id, command, `vim: ${fileName}: No such file or directory`, timestamp, 1);
     }
 
-    let content = '';
-    if (fileName.endsWith('.rs')) {
-      content = `fn main() {\n    println!("Hello, world!");\n}`;
-    } else if (fileName.endsWith('.toml')) {
-      content = `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`;
-    } else if (fileName.endsWith('.md')) {
-      content = `# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.`;
-    } else {
-      content = `Content of ${fileName}`;
+    const currentContents = this.fileSystemManager.getDirectoryContents(this.fileSystemManager.getCurrentPath());
+    const exists = currentContents?.some(item => item.name === fileName && item.type === 'file');
+
+    if (!exists) {
+      return this.generateCommand(id, command, `vim: ${fileName}: No such file or directory`, timestamp, 1);
     }
 
-    const lines = content.split('\n').map((line, idx) => `${(idx + 1).toString().padStart(4)} ${line}`);
-    const output = `Vim (read-only): ${fileName}\n${lines.join('\n')}`;
-    return this.generateCommand(id, command, output, timestamp);
+    return this.generateCommand(id, command, `__OPEN_EDITOR__${fileName}`, timestamp);
   }
 }

--- a/src/core/filesystem/FileSystemManager.ts
+++ b/src/core/filesystem/FileSystemManager.ts
@@ -24,6 +24,20 @@ export class FileSystemManager {
     '/tmp'
   ]);
 
+  private fileContents: Record<string, Record<string, string>> = {
+    '/home/user/project': {
+      'Cargo.toml': `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`,
+      'README.md': '# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.'
+    },
+    '/home/user/project/src': {
+      'main.rs': 'fn main() {\n    println!("Hello, world!");\n}',
+      'lib.rs': ''
+    },
+    '/home/user/documents': {
+      'notes.txt': 'These are some notes.'
+    }
+  };
+
   private fileSystem: FileSystem = {
     '/home': [
       { type: 'directory', name: 'user', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:30' }
@@ -132,6 +146,12 @@ export class FileSystemManager {
       this.fileSystem[path] = [];
     }
     this.fileSystem[path].push(node);
+    if (node.type === 'file') {
+      if (!this.fileContents[path]) {
+        this.fileContents[path] = {};
+      }
+      this.fileContents[path][node.name] = '';
+    }
   }
 
   createDirectory(path: string): void {
@@ -146,5 +166,17 @@ export class FileSystemManager {
         file.lastModified = new Date().toISOString().slice(0, 16).replace('T', ' ');
       }
     }
+  }
+
+  readFile(path: string, fileName: string): string {
+    return this.fileContents[path]?.[fileName] ?? '';
+  }
+
+  writeFile(path: string, fileName: string, content: string): void {
+    if (!this.fileContents[path]) {
+      this.fileContents[path] = {};
+    }
+    this.fileContents[path][fileName] = content;
+    this.updateFileTimestamp(path, fileName);
   }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -23,6 +23,14 @@ export interface TerminalCommand {
   exitCode: number;
 }
 
+export interface EditorSession {
+  id: string;
+  fileName: string;
+  content: string;
+  isActive: boolean;
+  createdAt: string;
+}
+
 export interface AuthState {
   isAuthenticated: boolean;
   user: User | null;

--- a/src/home/components/EditorTabs.tsx
+++ b/src/home/components/EditorTabs.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { EditorSession } from '@/core/types';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
+
+interface EditorTabsProps {
+  editors: EditorSession[];
+  activeEditorId: string;
+  onSwitchEditor: (id: string) => void;
+  onCloseEditor: (id: string) => void;
+}
+
+export const EditorTabs: React.FC<EditorTabsProps> = ({
+  editors,
+  activeEditorId,
+  onSwitchEditor,
+  onCloseEditor
+}) => {
+  if (editors.length === 0) return null;
+
+  return (
+    <div className="editor-tabs border-b border-green-600">
+      <ScrollArea className="w-full">
+        <div className="flex items-center min-w-max">
+          {editors.map((editor) => (
+            <div
+              key={editor.id}
+              className={`flex items-center border-r border-green-600 ${
+                editor.id === activeEditorId
+                  ? 'bg-green-900/30 text-green-300'
+                  : 'bg-gray-800 text-green-500 hover:bg-gray-700'
+              }`}
+            >
+              <button
+                onClick={() => onSwitchEditor(editor.id)}
+                className="px-3 py-2 font-mono text-sm transition-colors min-h-[48px] flex items-center whitespace-nowrap"
+              >
+                {editor.fileName}
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCloseEditor(editor.id);
+                }}
+                className="px-2 py-2 text-red-400 hover:text-red-300 transition-colors min-h-[48px] flex items-center"
+                aria-label="Close editor"
+              >
+                <X size={16} />
+              </button>
+            </div>
+          ))}
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+    </div>
+  );
+};

--- a/src/home/components/FileEditor.tsx
+++ b/src/home/components/FileEditor.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { EditorSession } from '@/core/types';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+interface FileEditorProps {
+  editor: EditorSession;
+  onSave: (id: string, content: string) => void;
+}
+
+export const FileEditor: React.FC<FileEditorProps> = ({ editor, onSave }) => {
+  const isMobile = useIsMobile();
+  const [content, setContent] = useState(editor.content);
+  const [mode, setMode] = useState<'insert' | 'normal'>('insert');
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isMobile) return;
+    if (mode === 'normal') {
+      if (e.key === 'i') {
+        setMode('insert');
+        e.preventDefault();
+      }
+      return;
+    }
+    if (e.key === 'Escape') {
+      setMode('normal');
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <div className="editor-container flex flex-col h-full">
+      <textarea
+        className="flex-1 bg-black text-green-300 font-mono p-2 outline-none resize-none"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      <div className="p-2 bg-gray-800 text-green-400 font-mono text-xs flex justify-between">
+        <span>{mode === 'insert' ? '-- INSERT --' : ''}</span>
+        <button onClick={() => onSave(editor.id, content)} className="hover:underline">
+          Save
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/home/view.tsx
+++ b/src/home/view.tsx
@@ -3,6 +3,8 @@ import React, { useState, useEffect } from 'react';
 import { HomeViewModel } from './viewModel';
 import { TerminalTabs } from './components/TerminalTabs';
 import { Terminal } from './components/Terminal';
+import { FileEditor } from './components/FileEditor';
+import { EditorTabs } from './components/EditorTabs';
 import { Button } from '@/components/ui/button';
 import { Plus } from 'lucide-react';
 import { useVisualViewport } from '../hooks/useVisualViewport';
@@ -62,9 +64,27 @@ export const HomeView: React.FC = () => {
     viewModel.closeSession(sessionId);
   };
 
+  const handleOpenEditor = (fileName: string) => {
+    viewModel.openEditor(fileName);
+  };
+
+  const handleSwitchEditor = (editorId: string) => {
+    viewModel.switchEditor(editorId);
+  };
+
+  const handleCloseEditor = (editorId: string) => {
+    viewModel.closeEditor(editorId);
+  };
+
+  const handleSaveEditor = (id: string, content: string) => {
+    viewModel.saveEditor(id, content);
+  };
+
   const currentUser = viewModel.getCurrentUser();
   const sessions = viewModel.getSessions();
   const activeSession = viewModel.getActiveSession();
+  const editors = viewModel.getEditors();
+  const activeEditor = viewModel.getActiveEditor();
 
   // If no sessions exist, show centered plus icon
   if (sessions.length === 0) {
@@ -109,14 +129,26 @@ export const HomeView: React.FC = () => {
         onNewSession={handleNewSession}
       />
 
+      <EditorTabs
+        editors={editors}
+        activeEditorId={activeEditor?.id || ''}
+        onSwitchEditor={handleSwitchEditor}
+        onCloseEditor={handleCloseEditor}
+      />
+
       {/* Terminal Content */}
-      {activeSession && (
-        <Terminal
-          session={activeSession}
-          currentPath={viewModel.getCurrentPath()}
-          onExecuteCommand={handleExecuteCommand}
-          username={currentUser?.username || 'user'}
-        />
+      {activeEditor ? (
+        <FileEditor editor={activeEditor} onSave={handleSaveEditor} />
+      ) : (
+        activeSession && (
+          <Terminal
+            session={activeSession}
+            currentPath={viewModel.getCurrentPath()}
+            onExecuteCommand={handleExecuteCommand}
+            username={currentUser?.username || 'user'}
+            onOpenEditor={handleOpenEditor}
+          />
+        )
       )}
     </div>
   );

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -66,7 +66,7 @@ describe('filesystem commands', () => {
   it('vim displays file with line numbers', () => {
     fsCmds.handleCd(['../documents'], '1', 'cd ../documents', ts);
     const res = fsCmds.handleVim(['notes.txt'], '1', 'vim notes.txt', ts);
-    expect(res.output).toContain('Vim (read-only): notes.txt');
+    expect(res.output).toBe('__OPEN_EDITOR__notes.txt');
   });
 });
 


### PR DESCRIPTION
## Summary
- simulate file editing via editor tabs
- track EditorSession objects in the view model
- update terminal component to emit editor events
- expose read/write helpers on command processor and filesystem
- adjust `vim` command to open an editor
- implement `FileEditor` and `EditorTabs` components
- update tests for new behaviour

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68473f23a7e88333825cbbbc1f6f38eb