### PR TITLE
Add simple file editor

### DIFF
--- a/src/core/SecureCommandProcessor.ts
+++ b/src/core/SecureCommandProcessor.ts
@@ -168,4 +168,22 @@ export class SecureCommandProcessor {
   getFileSystem() {
     return this.fileSystemManager.getFileSystem();
   }
+
+  readFile(path: string): string | null {
+    const normalized = this.fileSystemManager.normalizePath(path);
+    const parts = normalized.split('/').filter(p => p);
+    const fileName = parts.pop();
+    if (!fileName) return null;
+    const dir = '/' + parts.join('/');
+    return this.fileSystemManager.readFile(dir, fileName);
+  }
+
+  writeFile(path: string, content: string): void {
+    const normalized = this.fileSystemManager.normalizePath(path);
+    const parts = normalized.split('/').filter(p => p);
+    const fileName = parts.pop();
+    if (!fileName) return;
+    const dir = '/' + parts.join('/');
+    this.fileSystemManager.writeFile(dir, fileName, content);
+  }
 }

--- a/src/core/commands/filesystem/CatCommand.ts
+++ b/src/core/commands/filesystem/CatCommand.ts
@@ -21,17 +21,7 @@ export class CatCommand extends BaseCommandHandler {
       return this.generateCommand(id, command, `cat: ${fileName}: No such file or directory`, timestamp, 1);
     }
 
-    let content = '';
-    if (fileName.endsWith('.rs')) {
-      content = `fn main() {\n    println!("Hello, world!");\n}`;
-    } else if (fileName.endsWith('.toml')) {
-      content = `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`;
-    } else if (fileName.endsWith('.md')) {
-      content = `# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.`;
-    } else {
-      content = `Content of ${fileName}`;
-    }
-
+    const content = this.fileSystemManager.readFile(this.fileSystemManager.getCurrentPath(), fileName) ?? '';
     return this.generateCommand(id, command, content, timestamp);
   }
 }

--- a/src/core/commands/filesystem/TouchCommand.ts
+++ b/src/core/commands/filesystem/TouchCommand.ts
@@ -25,7 +25,8 @@ export class TouchCommand extends BaseCommandHandler {
         name: fileName,
         size: 0,
         permissions: '-rw-r--r--',
-        lastModified: new Date().toISOString().slice(0, 16).replace('T', ' ')
+        lastModified: new Date().toISOString().slice(0, 16).replace('T', ' '),
+        content: ''
       });
     }
 

--- a/src/core/commands/filesystem/VimCommand.ts
+++ b/src/core/commands/filesystem/VimCommand.ts
@@ -20,19 +20,6 @@ export class VimCommand extends BaseCommandHandler {
       return this.generateCommand(id, command, `vim: ${fileName}: No such file or directory`, timestamp, 1);
     }
 
-    let content = '';
-    if (fileName.endsWith('.rs')) {
-      content = `fn main() {\n    println!("Hello, world!");\n}`;
-    } else if (fileName.endsWith('.toml')) {
-      content = `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`;
-    } else if (fileName.endsWith('.md')) {
-      content = `# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.`;
-    } else {
-      content = `Content of ${fileName}`;
-    }
-
-    const lines = content.split('\n').map((line, idx) => `${(idx + 1).toString().padStart(4)} ${line}`);
-    const output = `Vim (read-only): ${fileName}\n${lines.join('\n')}`;
-    return this.generateCommand(id, command, output, timestamp);
+    return this.generateCommand(id, command, `Opened editor for ${fileName}`, timestamp);
   }
 }

--- a/src/core/filesystem/FileSystemManager.ts
+++ b/src/core/filesystem/FileSystemManager.ts
@@ -5,6 +5,7 @@ interface FileSystemNode {
   size?: number;
   permissions: string;
   lastModified: string;
+  content?: string;
 }
 
 interface FileSystem {
@@ -31,24 +32,24 @@ export class FileSystemManager {
     '/home/user': [
       { type: 'directory', name: 'project', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:30' },
       { type: 'directory', name: 'documents', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 09:15' },
-      { type: 'file', name: '.bashrc', size: 1024, permissions: '-rw-r--r--', lastModified: '2024-01-10 14:20' }
+      { type: 'file', name: '.bashrc', size: 1024, permissions: '-rw-r--r--', lastModified: '2024-01-10 14:20', content: '# .bashrc\nexport PATH="$PATH:/usr/local/bin"' }
     ],
     '/home/user/project': [
-      { type: 'file', name: 'Cargo.toml', size: 456, permissions: '-rw-r--r--', lastModified: '2024-01-15 10:30' },
+      { type: 'file', name: 'Cargo.toml', size: 456, permissions: '-rw-r--r--', lastModified: '2024-01-15 10:30', content: '[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"' },
       { type: 'directory', name: 'src', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:25' },
       { type: 'directory', name: 'target', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:28' },
-      { type: 'file', name: 'README.md', size: 2048, permissions: '-rw-r--r--', lastModified: '2024-01-15 09:45' }
+      { type: 'file', name: 'README.md', size: 2048, permissions: '-rw-r--r--', lastModified: '2024-01-15 09:45', content: '# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.' }
     ],
     '/home/user/project/src': [
-      { type: 'file', name: 'main.rs', size: 1536, permissions: '-rw-r--r--', lastModified: '2024-01-15 10:25' },
-      { type: 'file', name: 'lib.rs', size: 512, permissions: '-rw-r--r--', lastModified: '2024-01-15 09:30' }
+      { type: 'file', name: 'main.rs', size: 1536, permissions: '-rw-r--r--', lastModified: '2024-01-15 10:25', content: 'fn main() {\n    println!("Hello, world!");\n}' },
+      { type: 'file', name: 'lib.rs', size: 512, permissions: '-rw-r--r--', lastModified: '2024-01-15 09:30', content: '' }
     ],
     '/home/user/project/target': [
       { type: 'directory', name: 'debug', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:28' },
       { type: 'directory', name: 'release', permissions: 'drwxr-xr-x', lastModified: '2024-01-15 10:00' }
     ],
     '/home/user/documents': [
-      { type: 'file', name: 'notes.txt', size: 1024, permissions: '-rw-r--r--', lastModified: '2024-01-14 16:20' }
+      { type: 'file', name: 'notes.txt', size: 1024, permissions: '-rw-r--r--', lastModified: '2024-01-14 16:20', content: 'These are some notes.' }
     ]
   };
 
@@ -145,6 +146,22 @@ export class FileSystemManager {
       if (file) {
         file.lastModified = new Date().toISOString().slice(0, 16).replace('T', ' ');
       }
+    }
+  }
+
+  readFile(path: string, fileName: string): string | null {
+    const contents = this.fileSystem[path];
+    const file = contents?.find(item => item.name === fileName && item.type === 'file');
+    return file?.content ?? null;
+  }
+
+  writeFile(path: string, fileName: string, content: string): void {
+    const contents = this.fileSystem[path];
+    const file = contents?.find(item => item.name === fileName && item.type === 'file');
+    if (file) {
+      file.content = content;
+      file.size = content.length;
+      file.lastModified = new Date().toISOString().slice(0, 16).replace('T', ' ');
     }
   }
 }

--- a/src/home/components/EditorTabs.tsx
+++ b/src/home/components/EditorTabs.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { EditorSession } from '../viewModel';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
+
+interface EditorTabsProps {
+  sessions: EditorSession[];
+  activeId: string;
+  onSwitch: (id: string) => void;
+  onClose: (id: string) => void;
+}
+
+export const EditorTabs: React.FC<EditorTabsProps> = ({ sessions, activeId, onSwitch, onClose }) => {
+  if (sessions.length === 0) return null;
+
+  return (
+    <div className="editor-tabs flex border-b border-green-600">
+      {sessions.map(s => (
+        <div
+          key={s.id}
+          className={`flex items-center px-3 py-2 font-mono text-sm cursor-pointer ${
+            s.id === activeId ? 'bg-green-900/30 text-green-300' : 'bg-gray-800 text-green-500'
+          }`}
+          onClick={() => onSwitch(s.id)}
+        >
+          {s.fileName}
+          <Button
+            onClick={e => {
+              e.stopPropagation();
+              onClose(s.id);
+            }}
+            variant="ghost"
+            size="icon"
+            className="ml-2 h-4 w-4 text-red-400 hover:text-red-300"
+            aria-label="Close editor"
+          >
+            <X size={12} />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/home/components/FileEditor.tsx
+++ b/src/home/components/FileEditor.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { EditorSession } from '../viewModel';
+import { Button } from '@/components/ui/button';
+
+interface FileEditorProps {
+  session: EditorSession;
+  onChange: (content: string) => void;
+  onSave: () => void;
+}
+
+export const FileEditor: React.FC<FileEditorProps> = ({ session, onChange, onSave }) => {
+  return (
+    <div className="file-editor flex flex-col h-full">
+      <textarea
+        className="flex-1 bg-black text-green-400 font-mono p-2"
+        value={session.content}
+        onChange={e => onChange(e.target.value)}
+      />
+      <Button onClick={onSave} className="self-end m-2" size="sm">
+        Save
+      </Button>
+    </div>
+  );
+};

--- a/src/home/components/Terminal.tsx
+++ b/src/home/components/Terminal.tsx
@@ -7,6 +7,7 @@ interface TerminalProps {
   session: TerminalSession;
   currentPath: string;
   onExecuteCommand: (command: string) => void;
+  onOpenEditor?: (file: string) => void;
   username: string;
 }
 
@@ -14,6 +15,7 @@ export const Terminal: React.FC<TerminalProps> = ({
   session,
   currentPath,
   onExecuteCommand,
+  onOpenEditor,
   username
 }) => {
   const [currentInput, setCurrentInput] = useState('');
@@ -23,7 +25,12 @@ export const Terminal: React.FC<TerminalProps> = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (currentInput.trim()) {
-      onExecuteCommand(currentInput);
+      const cmd = currentInput.trim();
+      onExecuteCommand(cmd);
+      if (cmd.startsWith('vim ') && onOpenEditor) {
+        const file = cmd.slice(4).trim();
+        if (file) onOpenEditor(file);
+      }
       setCurrentInput('');
     }
   };

--- a/src/home/view.tsx
+++ b/src/home/view.tsx
@@ -2,6 +2,8 @@
 import React, { useState, useEffect } from 'react';
 import { HomeViewModel } from './viewModel';
 import { TerminalTabs } from './components/TerminalTabs';
+import { EditorTabs } from './components/EditorTabs';
+import { FileEditor } from './components/FileEditor';
 import { Terminal } from './components/Terminal';
 import { Button } from '@/components/ui/button';
 import { Plus } from 'lucide-react';
@@ -62,9 +64,31 @@ export const HomeView: React.FC = () => {
     viewModel.closeSession(sessionId);
   };
 
+  const handleOpenEditor = (file: string) => {
+    viewModel.openEditor(file);
+  };
+
+  const handleSwitchEditor = (id: string) => {
+    viewModel.setActiveEditor(id);
+  };
+
+  const handleCloseEditor = (id: string) => {
+    viewModel.closeEditor(id);
+  };
+
+  const handleUpdateEditor = (id: string, content: string) => {
+    viewModel.updateEditorContent(id, content);
+  };
+
+  const handleSaveEditor = (id: string) => {
+    viewModel.saveEditor(id);
+  };
+
   const currentUser = viewModel.getCurrentUser();
   const sessions = viewModel.getSessions();
   const activeSession = viewModel.getActiveSession();
+  const editorSessions = viewModel.getEditorSessions();
+  const activeEditor = viewModel.getActiveEditor();
 
   // If no sessions exist, show centered plus icon
   if (sessions.length === 0) {
@@ -109,13 +133,29 @@ export const HomeView: React.FC = () => {
         onNewSession={handleNewSession}
       />
 
+      <EditorTabs
+        sessions={editorSessions}
+        activeId={activeEditor?.id || ''}
+        onSwitch={handleSwitchEditor}
+        onClose={handleCloseEditor}
+      />
+
       {/* Terminal Content */}
       {activeSession && (
         <Terminal
           session={activeSession}
           currentPath={viewModel.getCurrentPath()}
           onExecuteCommand={handleExecuteCommand}
+          onOpenEditor={handleOpenEditor}
           username={currentUser?.username || 'user'}
+        />
+      )}
+
+      {activeEditor && (
+        <FileEditor
+          session={activeEditor}
+          onChange={content => handleUpdateEditor(activeEditor.id, content)}
+          onSave={() => handleSaveEditor(activeEditor.id)}
         />
       )}
     </div>

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -63,10 +63,10 @@ describe('filesystem commands', () => {
     expect(res.output).toContain('Hello');
   });
 
-  it('vim displays file with line numbers', () => {
+  it('vim opens editor', () => {
     fsCmds.handleCd(['../documents'], '1', 'cd ../documents', ts);
     const res = fsCmds.handleVim(['notes.txt'], '1', 'vim notes.txt', ts);
-    expect(res.output).toContain('Vim (read-only): notes.txt');
+    expect(res.output).toContain('Opened editor for notes.txt');
   });
 });
 


### PR DESCRIPTION
## Summary
- add content field and read/write helpers on `FileSystemManager`
- expose `readFile`/`writeFile` on `SecureCommandProcessor`
- update filesystem commands for new helpers
- implement `FileEditor` and `EditorTabs` components
- emit open editor event from `Terminal`
- support editor sessions in view model and view
- update Vim command to just signal editor open
- update tests

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run dev` *(fails: vite not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684751fcad948333ae6e393afbc49baa