### PR TITLE
Add file editor with tabs

### DIFF
--- a/src/core/SecureCommandProcessor.ts
+++ b/src/core/SecureCommandProcessor.ts
@@ -165,6 +165,14 @@ export class SecureCommandProcessor {
     return this.fileSystemManager.getCurrentPath();
   }
 
+  readFile(path: string): string | null {
+    return this.fileSystemManager.readFile(path);
+  }
+
+  writeFile(path: string, content: string): void {
+    this.fileSystemManager.writeFile(path, content);
+  }
+
   getFileSystem() {
     return this.fileSystemManager.getFileSystem();
   }

--- a/src/core/commands/filesystem/CatCommand.ts
+++ b/src/core/commands/filesystem/CatCommand.ts
@@ -14,22 +14,11 @@ export class CatCommand extends BaseCommandHandler {
     }
 
     const fileName = args[0];
-    const currentContents = this.fileSystemManager.getDirectoryContents(this.fileSystemManager.getCurrentPath());
-    const file = currentContents?.find(item => item.name === fileName && item.type === 'file');
-    
-    if (!file) {
-      return this.generateCommand(id, command, `cat: ${fileName}: No such file or directory`, timestamp, 1);
-    }
+    const filePath = this.fileSystemManager.normalizePath(fileName);
+    const content = this.fileSystemManager.readFile(filePath);
 
-    let content = '';
-    if (fileName.endsWith('.rs')) {
-      content = `fn main() {\n    println!("Hello, world!");\n}`;
-    } else if (fileName.endsWith('.toml')) {
-      content = `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`;
-    } else if (fileName.endsWith('.md')) {
-      content = `# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.`;
-    } else {
-      content = `Content of ${fileName}`;
+    if (content === null) {
+      return this.generateCommand(id, command, `cat: ${fileName}: No such file or directory`, timestamp, 1);
     }
 
     return this.generateCommand(id, command, content, timestamp);

--- a/src/core/commands/filesystem/TouchCommand.ts
+++ b/src/core/commands/filesystem/TouchCommand.ts
@@ -14,19 +14,16 @@ export class TouchCommand extends BaseCommandHandler {
     }
 
     const fileName = args[0];
-    const currentContents = this.fileSystemManager.getDirectoryContents(this.fileSystemManager.getCurrentPath());
-    const existingFile = currentContents.find(item => item.name === fileName);
-    
-    if (existingFile) {
-      this.fileSystemManager.updateFileTimestamp(this.fileSystemManager.getCurrentPath(), fileName);
+    const filePath = this.fileSystemManager.normalizePath(fileName);
+    const existingContent = this.fileSystemManager.readFile(filePath);
+
+    if (existingContent === null) {
+      this.fileSystemManager.writeFile(filePath, '');
     } else {
-      this.fileSystemManager.addFileSystemNode(this.fileSystemManager.getCurrentPath(), {
-        type: 'file',
-        name: fileName,
-        size: 0,
-        permissions: '-rw-r--r--',
-        lastModified: new Date().toISOString().slice(0, 16).replace('T', ' ')
-      });
+      this.fileSystemManager.updateFileTimestamp(
+        filePath.substring(0, filePath.lastIndexOf('/')) || '/',
+        fileName
+      );
     }
 
     return this.generateCommand(id, command, '', timestamp);

--- a/src/core/commands/filesystem/VimCommand.ts
+++ b/src/core/commands/filesystem/VimCommand.ts
@@ -1,4 +1,4 @@
-import { TerminalCommand } from '../../types';
+import { TerminalCommand, OPEN_EDITOR_PREFIX } from '../../types';
 import { BaseCommandHandler } from '../BaseCommandHandler';
 import { FileSystemManager } from '../../filesystem/FileSystemManager';
 
@@ -13,26 +13,13 @@ export class VimCommand extends BaseCommandHandler {
     }
 
     const fileName = args[0];
-    const currentContents = this.fileSystemManager.getDirectoryContents(this.fileSystemManager.getCurrentPath());
-    const file = currentContents?.find(item => item.name === fileName && item.type === 'file');
+    const filePath = this.fileSystemManager.normalizePath(fileName);
+    const content = this.fileSystemManager.readFile(filePath);
 
-    if (!file) {
+    if (content === null) {
       return this.generateCommand(id, command, `vim: ${fileName}: No such file or directory`, timestamp, 1);
     }
 
-    let content = '';
-    if (fileName.endsWith('.rs')) {
-      content = `fn main() {\n    println!("Hello, world!");\n}`;
-    } else if (fileName.endsWith('.toml')) {
-      content = `[package]\nname = "rust-project"\nversion = "0.1.0"\nedition = "2021"`;
-    } else if (fileName.endsWith('.md')) {
-      content = `# Rust Terminal Forge\n\nA secure terminal emulator built with Rust and React.`;
-    } else {
-      content = `Content of ${fileName}`;
-    }
-
-    const lines = content.split('\n').map((line, idx) => `${(idx + 1).toString().padStart(4)} ${line}`);
-    const output = `Vim (read-only): ${fileName}\n${lines.join('\n')}`;
-    return this.generateCommand(id, command, output, timestamp);
+    return this.generateCommand(id, command, `${OPEN_EDITOR_PREFIX}${filePath}`, timestamp);
   }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -23,6 +23,17 @@ export interface TerminalCommand {
   exitCode: number;
 }
 
+export interface EditorSession {
+  id: string;
+  filePath: string;
+  name: string;
+  content: string;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export const OPEN_EDITOR_PREFIX = '__OPEN_EDITOR__:';
+
 export interface AuthState {
   isAuthenticated: boolean;
   user: User | null;

--- a/src/home/components/EditorTabs.tsx
+++ b/src/home/components/EditorTabs.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { EditorSession } from '../../core/types';
+import { X } from 'lucide-react';
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
+
+interface EditorTabsProps {
+  sessions: EditorSession[];
+  activeSessionId: string;
+  onSwitchSession: (sessionId: string) => void;
+  onCloseSession: (sessionId: string) => void;
+}
+
+export const EditorTabs: React.FC<EditorTabsProps> = ({
+  sessions,
+  activeSessionId,
+  onSwitchSession,
+  onCloseSession
+}) => {
+  if (sessions.length === 0) return null;
+
+  return (
+    <div className="terminal-tabs">
+      <ScrollArea className="w-full">
+        <div className="flex items-center min-w-max">
+          {sessions.map((session) => (
+            <div
+              key={session.id}
+              className={`flex items-center border-r border-green-600 ${
+                session.id === activeSessionId
+                  ? 'bg-green-900/30 text-green-300'
+                  : 'bg-gray-800 text-green-500 hover:bg-gray-700'
+              }`}
+            >
+              <button
+                onClick={() => onSwitchSession(session.id)}
+                className="px-3 sm:px-4 py-2 sm:py-3 font-mono text-sm sm:text-base transition-colors min-h-[48px] flex items-center whitespace-nowrap touch-manipulation"
+              >
+                {session.name}
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCloseSession(session.id);
+                }}
+                className="px-2 py-2 sm:py-3 text-red-400 hover:text-red-300 transition-colors min-h-[48px] flex items-center touch-manipulation"
+                aria-label="Close editor"
+              >
+                <X size={16} />
+              </button>
+            </div>
+          ))}
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+    </div>
+  );
+};

--- a/src/home/components/FileEditor.tsx
+++ b/src/home/components/FileEditor.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { EditorSession } from '../../core/types';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface FileEditorProps {
+  session: EditorSession;
+  onSave: (content: string) => void;
+}
+
+export const FileEditor: React.FC<FileEditorProps> = ({ session, onSave }) => {
+  const [content, setContent] = useState(session.content);
+
+  return (
+    <div className="flex flex-col h-full">
+      <Textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        className="flex-1 font-mono bg-black text-green-300"
+      />
+      <div className="mt-2">
+        <Button size="sm" onClick={() => onSave(content)}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/home/view.tsx
+++ b/src/home/view.tsx
@@ -2,7 +2,9 @@
 import React, { useState, useEffect } from 'react';
 import { HomeViewModel } from './viewModel';
 import { TerminalTabs } from './components/TerminalTabs';
+import { EditorTabs } from './components/EditorTabs';
 import { Terminal } from './components/Terminal';
+import { FileEditor } from './components/FileEditor';
 import { Button } from '@/components/ui/button';
 import { Plus } from 'lucide-react';
 import { useVisualViewport } from '../hooks/useVisualViewport';
@@ -62,9 +64,27 @@ export const HomeView: React.FC = () => {
     viewModel.closeSession(sessionId);
   };
 
+  const handleOpenEditor = (filePath: string) => {
+    viewModel.openEditor(filePath);
+  };
+
+  const handleSwitchEditor = (sessionId: string) => {
+    viewModel.switchEditor(sessionId);
+  };
+
+  const handleCloseEditor = (sessionId: string) => {
+    viewModel.closeEditor(sessionId);
+  };
+
+  const handleSaveEditor = (sessionId: string, content: string) => {
+    viewModel.updateEditorContent(sessionId, content);
+  };
+
   const currentUser = viewModel.getCurrentUser();
   const sessions = viewModel.getSessions();
   const activeSession = viewModel.getActiveSession();
+  const editorSessions = viewModel.getEditorSessions();
+  const activeEditor = viewModel.getActiveEditor();
 
   // If no sessions exist, show centered plus icon
   if (sessions.length === 0) {
@@ -109,13 +129,28 @@ export const HomeView: React.FC = () => {
         onNewSession={handleNewSession}
       />
 
+      <EditorTabs
+        sessions={editorSessions}
+        activeSessionId={activeEditor?.id || ''}
+        onSwitchSession={handleSwitchEditor}
+        onCloseSession={handleCloseEditor}
+      />
+
       {/* Terminal Content */}
       {activeSession && (
         <Terminal
           session={activeSession}
           currentPath={viewModel.getCurrentPath()}
           onExecuteCommand={handleExecuteCommand}
+          onOpenEditor={handleOpenEditor}
           username={currentUser?.username || 'user'}
+        />
+      )}
+
+      {activeEditor && (
+        <FileEditor
+          session={activeEditor}
+          onSave={(content) => handleSaveEditor(activeEditor.id, content)}
         />
       )}
     </div>

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -3,6 +3,7 @@ import { FileSystemManager } from '../src/core/filesystem/FileSystemManager';
 import { FileSystemCommands } from '../src/core/commands/FileSystemCommands';
 import { SystemCommands } from '../src/core/commands/SystemCommands';
 import { UtilityCommands } from '../src/core/commands/UtilityCommands';
+import { OPEN_EDITOR_PREFIX } from '../src/core/types';
 
 let fsManager: FileSystemManager;
 let fsCmds: FileSystemCommands;
@@ -66,7 +67,7 @@ describe('filesystem commands', () => {
   it('vim displays file with line numbers', () => {
     fsCmds.handleCd(['../documents'], '1', 'cd ../documents', ts);
     const res = fsCmds.handleVim(['notes.txt'], '1', 'vim notes.txt', ts);
-    expect(res.output).toContain('Vim (read-only): notes.txt');
+    expect(res.output).toBe(`${OPEN_EDITOR_PREFIX}/home/user/documents/notes.txt`);
   });
 });
 


### PR DESCRIPTION
## Summary
- store file contents in `FileSystemManager` and add helpers for reading/writing
- expose `readFile`/`writeFile` in `SecureCommandProcessor`
- update filesystem commands to use new helpers
- return editor open signal from `vim` command
- add `FileEditor` and `EditorTabs` components
- support editor sessions in view model and view
- trigger editor open in `Terminal`
- adjust tests for new `vim` behaviour

## Testing
- `npm run build`
- `npm run dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684755ae54648333baee7ded7583390c