### PR TITLE
Fix history numbering bug

### DIFF
--- a/src/core/commands/UtilityCommands.ts
+++ b/src/core/commands/UtilityCommands.ts
@@ -30,9 +30,10 @@ export class UtilityCommands extends BaseCommandHandler {
   }
 
   handleHistory(id: string, command: string, timestamp: string): TerminalCommand {
+    const startIndex = Math.max(0, this.commandHistory.length - 50);
     const historyOutput = this.commandHistory
       .slice(-50)
-      .map((cmd, index) => `${(this.commandHistory.length - 50 + index + 1).toString().padStart(4)}: ${cmd}`)
+      .map((cmd, index) => `${(startIndex + index + 1).toString().padStart(4)}: ${cmd}`)
       .join('\n');
 
     return this.generateCommand(id, command, historyOutput, timestamp);

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -104,6 +104,13 @@ describe('utility commands', () => {
     expect(res.output).toContain('ls');
   });
 
+  it('history numbering starts at 1 when less than max entries', () => {
+    utilCmds.addToHistory('cd ..');
+    const res = utilCmds.handleHistory('1', 'history', ts);
+    const firstLine = res.output.split('\n')[0];
+    expect(firstLine.trim().startsWith('1:')).toBe(true);
+  });
+
   it('alias lists existing aliases', () => {
     const res = utilCmds.handleAlias([], '1', 'alias', ts);
     expect(res.output).toContain("alias ll='ls -la'");


### PR DESCRIPTION
## Summary
- correct numbering in command history when fewer than 50 entries
- test that history numbering starts at 1

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6860056f4e5c83338e353c272d11dda5