### PR TITLE
Feature: add uptime command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ Once deployed, your site will be available at `https://<OWNER>.github.io/rust-te
 </details>
 
 <details>
+<summary><strong>Common commands</strong></summary>
+
+Use `help` inside the terminal for the full list. Recent addition: the `uptime` command displays how long the system has been running.
+
+</details>
+
+<details>
 <summary><strong>Can I connect a custom domain to my Lovable project?</strong></summary>
 
 Yes, you can!

--- a/src/core/SecureCommandProcessor.ts
+++ b/src/core/SecureCommandProcessor.ts
@@ -81,6 +81,8 @@ export class SecureCommandProcessor {
           return this.systemCommands.handleDate(id, command, timestamp);
         case 'env':
           return this.systemCommands.handleEnv(id, command, timestamp);
+        case 'uptime':
+          return this.systemCommands.handleUptime(id, command, timestamp);
         case 'which':
           return this.systemCommands.handleWhich(args, id, command, timestamp);
         case 'history':
@@ -132,7 +134,7 @@ export class SecureCommandProcessor {
   }
 
   private suggestCommand(command: string): string {
-    const commands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'find', 'grep', 'vim', 'echo', 'whoami', 'date', 'env', 'which', 'history', 'alias', 'cargo', 'clear', 'help'];
+    const commands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'find', 'grep', 'vim', 'echo', 'whoami', 'date', 'env', 'uptime', 'which', 'history', 'alias', 'cargo', 'clear', 'help'];
     const suggestions = commands.filter(cmd => 
       cmd.includes(command) || 
       this.levenshteinDistance(cmd, command) <= 2

--- a/src/core/commands/SystemCommands.ts
+++ b/src/core/commands/SystemCommands.ts
@@ -31,13 +31,18 @@ export class SystemCommands extends BaseCommandHandler {
     return this.generateCommand(id, command, envVars.join('\n'), timestamp);
   }
 
+  handleUptime(id: string, command: string, timestamp: string): TerminalCommand {
+    const output = 'up 1 day, 0:00, load average: 0.00, 0.00, 0.00';
+    return this.generateCommand(id, command, output, timestamp);
+  }
+
   handleWhich(args: string[], id: string, command: string, timestamp: string): TerminalCommand {
     if (args.length === 0) {
       return this.generateCommand(id, command, 'which: missing operand', timestamp, 1);
     }
 
     const commandName = args[0];
-    const builtinCommands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'history', 'alias', 'cargo', 'clear', 'help', 'echo', 'whoami', 'date', 'env', 'which'];
+    const builtinCommands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'history', 'alias', 'cargo', 'clear', 'help', 'echo', 'whoami', 'date', 'env', 'which', 'uptime'];
     
     if (builtinCommands.includes(commandName)) {
       return this.generateCommand(id, command, `/usr/bin/${commandName}`, timestamp);

--- a/src/core/commands/UtilityCommands.ts
+++ b/src/core/commands/UtilityCommands.ts
@@ -77,6 +77,7 @@ export class UtilityCommands extends BaseCommandHandler {
   whoami     - Show current user
   date       - Show current date and time
   env        - Show environment variables
+  uptime     - Show how long the system has been running
   which      - Locate a command
   history    - Show command history
   alias      - Show or set command aliases

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -91,6 +91,11 @@ describe('system commands', () => {
     expect(res.output).toContain('HOME=/home/user');
   });
 
+  it('uptime displays system uptime', () => {
+    const res = sysCmds.handleUptime('1', 'uptime', ts);
+    expect(res.output).toContain('load average');
+  });
+
   it('which finds builtin command', () => {
     const res = sysCmds.handleWhich(['ls'], '1', 'which ls', ts);
     expect(res.output).toContain('/usr/bin/ls');


### PR DESCRIPTION
## Summary
- add `uptime` command implementation
- support command in SecureCommandProcessor and help text
- document uptime support in README
- test uptime behavior

## Codex CI
- `npm ci`
- `npm run build`
- `npm run typecheck` *(fails: Missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68600e8d85cc8333a0bb2b9183a85a24