### PR TITLE
Feature: add hostname command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Once deployed, your site will be available at `https://<OWNER>.github.io/rust-te
 <details>
 <summary><strong>Common commands</strong></summary>
 
-Use `help` inside the terminal for the full list. Recent addition: the `uptime` command displays how long the system has been running.
+Use `help` inside the terminal for the full list. Recent additions: the `uptime` command displays how long the system has been running and `hostname` shows the server name.
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run"
   },

--- a/src/core/SecureCommandProcessor.ts
+++ b/src/core/SecureCommandProcessor.ts
@@ -83,6 +83,8 @@ export class SecureCommandProcessor {
           return this.systemCommands.handleEnv(id, command, timestamp);
         case 'uptime':
           return this.systemCommands.handleUptime(id, command, timestamp);
+        case 'hostname':
+          return this.systemCommands.handleHostname(id, command, timestamp);
         case 'which':
           return this.systemCommands.handleWhich(args, id, command, timestamp);
         case 'history':
@@ -134,7 +136,7 @@ export class SecureCommandProcessor {
   }
 
   private suggestCommand(command: string): string {
-    const commands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'find', 'grep', 'vim', 'echo', 'whoami', 'date', 'env', 'uptime', 'which', 'history', 'alias', 'cargo', 'clear', 'help'];
+    const commands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'find', 'grep', 'vim', 'echo', 'whoami', 'date', 'env', 'uptime', 'hostname', 'which', 'history', 'alias', 'cargo', 'clear', 'help'];
     const suggestions = commands.filter(cmd => 
       cmd.includes(command) || 
       this.levenshteinDistance(cmd, command) <= 2

--- a/src/core/commands/SystemCommands.ts
+++ b/src/core/commands/SystemCommands.ts
@@ -36,13 +36,17 @@ export class SystemCommands extends BaseCommandHandler {
     return this.generateCommand(id, command, output, timestamp);
   }
 
+  handleHostname(id: string, command: string, timestamp: string): TerminalCommand {
+    return this.generateCommand(id, command, 'terminal-forge', timestamp);
+  }
+
   handleWhich(args: string[], id: string, command: string, timestamp: string): TerminalCommand {
     if (args.length === 0) {
       return this.generateCommand(id, command, 'which: missing operand', timestamp, 1);
     }
 
     const commandName = args[0];
-    const builtinCommands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'history', 'alias', 'cargo', 'clear', 'help', 'echo', 'whoami', 'date', 'env', 'which', 'uptime'];
+    const builtinCommands = ['pwd', 'ls', 'cd', 'mkdir', 'touch', 'cat', 'history', 'alias', 'cargo', 'clear', 'help', 'echo', 'whoami', 'date', 'env', 'which', 'uptime', 'hostname'];
     
     if (builtinCommands.includes(commandName)) {
       return this.generateCommand(id, command, `/usr/bin/${commandName}`, timestamp);

--- a/src/core/commands/UtilityCommands.ts
+++ b/src/core/commands/UtilityCommands.ts
@@ -78,6 +78,7 @@ export class UtilityCommands extends BaseCommandHandler {
   date       - Show current date and time
   env        - Show environment variables
   uptime     - Show how long the system has been running
+  hostname   - Display host name
   which      - Locate a command
   history    - Show command history
   alias      - Show or set command aliases

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -96,6 +96,11 @@ describe('system commands', () => {
     expect(res.output).toContain('load average');
   });
 
+  it('hostname returns host name', () => {
+    const res = sysCmds.handleHostname('1', 'hostname', ts);
+    expect(res.output).toBe('terminal-forge');
+  });
+
   it('which finds builtin command', () => {
     const res = sysCmds.handleWhich(['ls'], '1', 'which ls', ts);
     expect(res.output).toContain('/usr/bin/ls');
@@ -129,5 +134,6 @@ describe('utility commands', () => {
   it('help shows help text', () => {
     const res = utilCmds.handleHelp('1', 'help', ts);
     expect(res.output).toContain('Available commands');
+    expect(res.output).toContain('hostname');
   });
 });


### PR DESCRIPTION
## Summary
- add new `hostname` command to display server name
- include command in help output and suggestions
- ensure `hostname` is recognized by `which`
- add `typecheck` script
- document new command in README

## Codex CI
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68602b52022c8333a920260e61e522b8