### PR TITLE
Feature: clear command history

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Once deployed, your site will be available at `https://<OWNER>.github.io/rust-te
 <details>
 <summary><strong>Common commands</strong></summary>
 
-Use `help` inside the terminal for the full list. Recent additions: the `uptime` command displays how long the system has been running and `hostname` shows the server name.
+Use `help` inside the terminal for the full list. Recent additions: the `uptime` command displays how long the system has been running and `hostname` shows the server name. You can now clear the command history with `history -c`.
 
 </details>
 

--- a/src/core/commands/UtilityCommands.ts
+++ b/src/core/commands/UtilityCommands.ts
@@ -30,6 +30,12 @@ export class UtilityCommands extends BaseCommandHandler {
   }
 
   handleHistory(id: string, command: string, timestamp: string): TerminalCommand {
+    const args = command.split(/\s+/).slice(1);
+    if (args.includes('-c')) {
+      this.commandHistory = [];
+      return this.generateCommand(id, command, '', timestamp);
+    }
+
     const startIndex = Math.max(0, this.commandHistory.length - 50);
     const historyOutput = this.commandHistory
       .slice(-50)
@@ -81,6 +87,7 @@ export class UtilityCommands extends BaseCommandHandler {
   hostname   - Display host name
   which      - Locate a command
   history    - Show command history
+    -c       - Clear command history
   alias      - Show or set command aliases
   cargo      - Rust package manager
     build    - Compile the current package

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -121,6 +121,16 @@ describe('utility commands', () => {
     expect(firstLine.trim().startsWith('1:')).toBe(true);
   });
 
+  it('history -c clears command history', () => {
+    utilCmds.addToHistory('ls');
+    utilCmds.addToHistory('pwd');
+    const clearRes = utilCmds.handleHistory('1', 'history -c', ts);
+    expect(clearRes.exitCode).toBe(0);
+    expect(clearRes.output).toBe('');
+    const res = utilCmds.handleHistory('1', 'history', ts);
+    expect(res.output).toBe('');
+  });
+
   it('alias lists existing aliases', () => {
     const res = utilCmds.handleAlias([], '1', 'alias', ts);
     expect(res.output).toContain("alias ll='ls -la'");


### PR DESCRIPTION
## Summary
- allow clearing command history with `history -c`
- document the new option in README and help text
- test new history clear functionality

## Codex CI
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686030ca07348333998c2c39bb8225d5