### PR TITLE
Feature: add cd - command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Once deployed, your site will be available at `https://<OWNER>.github.io/rust-te
 <details>
 <summary><strong>Common commands</strong></summary>
 
-Use `help` inside the terminal for the full list. Recent additions: the `uptime` command displays how long the system has been running and `hostname` shows the server name. You can now clear the command history with `history -c`.
+Use `help` inside the terminal for the full list. Recent additions: the `uptime` command displays how long the system has been running and `hostname` shows the server name. You can now clear the command history with `history -c` and jump back to the previous directory with `cd -`.
 
 </details>
 

--- a/src/core/commands/UtilityCommands.ts
+++ b/src/core/commands/UtilityCommands.ts
@@ -74,7 +74,7 @@ export class UtilityCommands extends BaseCommandHandler {
     const helpText = `Available commands:
   pwd        - Show current directory
   ls [-lah]  - List directory contents
-  cd <dir>   - Change directory (supports: ., .., ~, absolute and relative paths)
+  cd <dir>   - Change directory (supports: ., .., -, ~, absolute and relative paths)
   mkdir      - Create directory
   touch      - Create or update file
   cat        - Display file contents
@@ -100,6 +100,7 @@ export class UtilityCommands extends BaseCommandHandler {
 Navigation examples:
   cd .       - Stay in current directory
   cd ..      - Go up one level
+  cd -       - Go to previous directory
   cd ~       - Go to home directory
   cd /path   - Go to absolute path
   cd folder  - Go to subfolder`;

--- a/src/core/commands/filesystem/CdCommand.ts
+++ b/src/core/commands/filesystem/CdCommand.ts
@@ -15,6 +15,12 @@ export class CdCommand extends BaseCommandHandler {
     }
 
     const targetPath = args[0];
+
+    if (targetPath === '-') {
+      const previous = this.fileSystemManager.getPreviousPath();
+      this.fileSystemManager.setCurrentPath(previous);
+      return this.generateCommand(id, command, '', timestamp);
+    }
     
     // Custom behavior: cd . goes up one level, cd .. goes up two levels
     if (targetPath === '.') {

--- a/src/core/filesystem/FileSystemManager.ts
+++ b/src/core/filesystem/FileSystemManager.ts
@@ -13,6 +13,7 @@ interface FileSystem {
 
 export class FileSystemManager {
   private currentPath: string = '/home/user/project';
+  private previousPath: string = '/home/user/project';
   private readonly homeDirectory: string = '/home/user';
   private readonly allowedPaths: Set<string> = new Set([
     '/home',
@@ -112,7 +113,12 @@ export class FileSystemManager {
   }
 
   setCurrentPath(path: string): void {
+    this.previousPath = this.currentPath;
     this.currentPath = path;
+  }
+
+  getPreviousPath(): string {
+    return this.previousPath;
   }
 
   getHomeDirectory(): string {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -33,6 +33,14 @@ describe('filesystem commands', () => {
     expect(fsManager.getCurrentPath()).toBe('/home');
   });
 
+  it('cd - returns to previous directory', () => {
+    fsCmds.handleCd(['src'], '1', 'cd src', ts);
+    fsCmds.handleCd(['-'], '1', 'cd -', ts);
+    expect(fsManager.getCurrentPath()).toBe('/home/user/project');
+    fsCmds.handleCd(['-'], '1', 'cd -', ts);
+    expect(fsManager.getCurrentPath()).toBe('/home/user/project/src');
+  });
+
   it('mkdir creates directory', () => {
     const res = fsCmds.handleMkdir(['newdir'], '1', 'mkdir newdir', ts);
     expect(res.exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- add a `previousPath` tracker in `FileSystemManager`
- implement `cd -` handling in `CdCommand`
- document and expose the new feature in the help text and README
- test toggling to the previous directory

## Codex CI
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860505c645083339b5e845c42b6d709