### PR TITLE
Feature: history -n option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Once deployed, your site will be available at `https://<OWNER>.github.io/rust-te
 <details>
 <summary><strong>Common commands</strong></summary>
 
-Use `help` inside the terminal for the full list. Recent additions: the `uptime` command displays how long the system has been running and `hostname` shows the server name. You can now clear the command history with `history -c` and jump back to the previous directory with `cd -`.
+Use `help` inside the terminal for the full list. Recent additions: the `uptime` command displays how long the system has been running and `hostname` shows the server name. You can now clear the command history with `history -c`, limit output with `history -n <count>`, and jump back to the previous directory with `cd -`.
 
 </details>
 

--- a/src/core/commands/UtilityCommands.ts
+++ b/src/core/commands/UtilityCommands.ts
@@ -36,9 +36,18 @@ export class UtilityCommands extends BaseCommandHandler {
       return this.generateCommand(id, command, '', timestamp);
     }
 
-    const startIndex = Math.max(0, this.commandHistory.length - 50);
+    let count = 50;
+    const nIndex = args.indexOf('-n');
+    if (nIndex !== -1 && args[nIndex + 1]) {
+      const parsed = parseInt(args[nIndex + 1], 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        count = parsed;
+      }
+    }
+
+    const startIndex = Math.max(0, this.commandHistory.length - count);
     const historyOutput = this.commandHistory
-      .slice(-50)
+      .slice(-count)
       .map((cmd, index) => `${(startIndex + index + 1).toString().padStart(4)}: ${cmd}`)
       .join('\n');
 
@@ -88,6 +97,7 @@ export class UtilityCommands extends BaseCommandHandler {
   which      - Locate a command
   history    - Show command history
     -c       - Clear command history
+    -n <num> - Show last <num> entries
   alias      - Show or set command aliases
   cargo      - Rust package manager
     build    - Compile the current package

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -139,6 +139,17 @@ describe('utility commands', () => {
     expect(res.output).toBe('');
   });
 
+  it('history -n limits output to the last n entries', () => {
+    for (let i = 0; i < 5; i++) {
+      utilCmds.addToHistory(`cmd${i}`);
+    }
+    const res = utilCmds.handleHistory('1', 'history -n 3', ts);
+    const lines = res.output.split('\n');
+    expect(lines).toHaveLength(3);
+    const firstLineNumber = parseInt(lines[0].split(':')[0], 10);
+    expect(firstLineNumber).toBe(3);
+  });
+
   it('alias lists existing aliases', () => {
     const res = utilCmds.handleAlias([], '1', 'alias', ts);
     expect(res.output).toContain("alias ll='ls -la'");


### PR DESCRIPTION
## Summary
- add `history -n` option to view a limited number of commands
- document the new option in the help text and README
- test coverage for the new behaviour

## Codex CI
- `npm ci` ✅
- `npm run build` ✅
- `npm run typecheck` ✅
- `npm test` ✅

------
https://chatgpt.com/codex/tasks/task_e_6862935be8548333b274598917a689f8