### PR TITLE
Feature: add software engineering laws

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1336,6 +1336,239 @@ const processOrder = (order: Order) => {
 - [Kent C. Dodds Testing JavaScript](https://testingjavascript.com/)
 - [Functional Programming in TypeScript](https://gcanti.github.io/fp-ts/)
 
+# Software Engineering Laws: Expanded Interpretations & Examples
+
+## Index
+
+- Murphy’s Law  
+- Brook’s Law  
+- Hofstadter’s Law  
+- Conway’s Law  
+- Postel’s Law  
+- Pareto Principle  
+- The Peter Principle  
+- Kerckhoffs’s Principle  
+- Linus’s Law  
+- Moore’s Law  
+- Wirth’s Law  
+- Ninety-ninety Rule  
+- Knuth’s Optimization Principle  
+- Norvig’s Law  
+
+## Murphy’s Law
+
+> **“Anything that can go wrong, will go wrong.”**
+
+**Interpretation:**  
+No matter how bullet-proof your design, unexpected failures—bugs, infrastructure outages, security incidents—will happen. Defensive coding, exhaustive testing (TDD/MDD), robust CI/CD, and disaster-recovery plans are your shield.
+
+**Good Examples:**
+1. **Startup**: A two-person fintech startup adopted feature flags and automated rollback in their CI pipeline. When a corner-case bug in payments surfaced in production, they disabled the feature flag instantly and fixed it within hours—averting financial loss.
+2. **Open Source**: The maintainers of a cross-platform library ran CI tests on Linux, macOS, Windows, and FreeBSD. When a compiler update broke one target, the CI alerts caught it before any downstream projects were impacted.
+
+**Bad Examples:**
+1. **FAANG**: A service team pushed a database schema change without backward-compatibility checks. When cache nodes failed to migrate, the entire global service was unavailable for four hours.
+2. **AAA Gaming**: A console title shipped with an untested physics edge case. Players encountering the rare scenario saw the game crash near end-boss fights, triggering negative reviews and emergency patches.
+
+## Brook’s Law
+
+> **“Adding manpower to a late software project makes it later.”**
+
+**Interpretation:**  
+Onboarding new team members consumes time—mentoring, code reviews, communication overhead. Simply hiring more developers rarely accelerates a delayed project; better to refine scope, improve processes, or refactor architecture.
+
+**Good Examples:**
+1. **AAA Studio (Ubisoft)**: Rather than hiring ten junior designers mid-sprint, leadership brought in two senior producers to streamline the pipeline, reprioritize features, and unblock existing engineers—accelerating delivery.
+2. **Open Source**: Instead of recruiting more maintainers when a release lagged, the project improved contributor documentation and CI guidance, reducing ramp-up time and getting volunteers up to speed faster.
+
+**Bad Examples:**
+1. **FAANG**: A datacenter team added six engineers to fix a lagging monitoring service. Time spent teaching code standards and architecture nuances pushed the deadline further out.
+2. **Early-Stage Startup**: Founders panicked, hired four fresh graduates to meet a launch date. The ramp-up and hand-holding required derailed core feature work, delaying release by months.
+
+## Hofstadter’s Law
+
+> **“It always takes longer than you expect, even when you take into account Hofstadter’s Law.”**
+
+**Interpretation:**  
+Estimating complex tasks is inherently flawed. Even with experience, unforeseen complications—third-party quirks, architectural edge cases, shifting requirements—inflate timelines. Always pad your estimates.
+
+**Good Examples:**
+1. **Nvidia Driver Team**: Engineers built in a 25% time buffer for a major driver rewrite. When hardware quirks surfaced, the project still finished on schedule.
+2. **FAANG Agile Squad**: Adopted sprint planning with built-in “slack” stories. When an integration issue ate up half a sprint, they still met deliverables by deferring low-priority items.
+
+**Bad Examples:**
+1. **Startup MVP**: Team promised a working prototype in four weeks. Unexpected API rate limits and refactoring took six months—burning through runway.
+2. **Game Engine Rewrite**: A AAA studio estimated a quarter for a refactor; under-estimated deep coupling, resulting in repeated delays and feature freezes.
+
+## Conway’s Law
+
+> **“Organizations which design systems are constrained to produce designs which are copies of the communication structures of these organizations.”**
+
+**Interpretation:**  
+Your team topology shapes your architecture. Siloed teams yield siloed code; cross-functional squads yield cohesive services. Align team boundaries with desired system modules to minimize handoffs.
+
+**Good Examples:**
+1. **FAANG Microservices**: Cross-functional “service teams” owned each microservice end-to-end—frontend, backend, infrastructure—delivering independent deploys with minimal coordination.
+2. **AAA Game Feature Teams**: Designers, artists, and gameplay engineers formed stable pods around major features (e.g., AI systems), leading to tighter integration and faster iteration.
+
+**Bad Examples:**
+1. **Legacy Monolith**: Frontend, backend, and DB teams worked in silos. Every UI tweak required three separate pull requests and cross-team meetings, causing weeks of delay.
+2. **Small Startup**: Developers split by language (Java vs. JavaScript). API mismatches and duplicated logic plagued the codebase, as feature boundaries didn’t match team skills.
+
+## Postel’s Law
+
+> **“Be conservative in what you send, be liberal in what you accept.”**
+
+**Interpretation:**  
+Design your outputs strictly (predictable formats), but parse inputs flexibly (tolerant of variations). This robustness principle underpins resilient networks and APIs—too lax in output or too strict in input both cause failures.
+
+**Good Examples:**
+1. **Open Source HTTP Client**: Strictly formats headers on send but tolerates missing or reordered headers in responses, improving compatibility with varied servers.
+2. **Game Engine Plugin API**: Engine writes standardized JSON logs but accepts plugin configs with minor formatting differences, reducing integration friction.
+
+**Bad Examples:**
+1. **FAANG Analytics Service**: Accepted any malformed telemetry until storage filled with garbage data, corrupting dashboards and BI reports.
+2. **Early-Stage Startup Form**: Over-permissive input sanitization allowed SQL injection attacks when users submitted unexpected characters.
+
+## Pareto Principle
+
+> **“80% of consequences come from 20% of causes.”**
+
+**Interpretation:**  
+A small fraction of your code typically produces most bugs or carries most performance weight. Focus efforts on that critical “20%” to maximize impact—whether fixing bugs, refactoring hot spots, or writing docs.
+
+**Good Examples:**
+1. **FAANG DB Team**: Profiled queries, optimized the top 20% slowest, and saw overall load-time drop by 70%.
+2. **Open Source Library**: Identified the 20% of API methods used by 80% of clients; improved their docs and stability, reducing support issues.
+
+**Bad Examples:**
+1. **AAA UI Polish**: Spent weeks animating secondary menus (used <10% by players) while core gameplay suffered frame-rate issues.
+2. **Startup Feature Bloat**: Built niche integrations for a tiny customer subset, neglecting core UX, resulting in poor adoption.
+
+## The Peter Principle
+
+> **“In a hierarchy, every employee tends to rise to his level of incompetence.”**
+
+**Interpretation:**  
+Engineers promoted for coding skill often struggle when moved into management roles. Without parallel technical and managerial tracks, organizations lose both coding capacity and leadership quality.
+
+**Good Examples:**
+1. **FAANG Dual Ladder**: Engineers choose between an “IC path” or “Manager path.” Top individual contributors advance technically without forced people management.
+2. **AAA Studio Mentorship**: Senior devs promoted to “Tech Lead” received coaching in leadership and people skills—reducing turnover and performance dips.
+
+**Bad Examples:**
+1. **Startup**: A star coder was promoted to CTO without management training; project delivery suffered due to poor delegation and communication.
+2. **Large Corp**: Ineffective manager promoted repeatedly; team morale plummeted and attrition spiked.
+
+## Kerckhoffs’s Principle
+
+> **“A cryptosystem should be secure even if everything about the system, except the key, is public knowledge.”**
+
+**Interpretation:**  
+Never depend on secrecy of algorithms—security must rest solely on key confidentiality. Public scrutiny (open algorithms) strengthens confidence.
+
+**Good Examples:**
+1. **Open Source Crypto Library**: Published algorithm specs, focused audits on key storage and management, earning enterprise trust.
+2. **FAANG Service Encryption**: Used industry-standard AES; all code public, key material stored in hardware security modules (HSMs).
+
+**Bad Examples:**
+1. **Early-Stage Startup**: Rolled a proprietary cipher believing obscurity would protect them; attackers reversed it in days.
+2. **AAA DRM System**: Obfuscated key handling in game client; hackers extracted keys and cracked content within weeks.
+
+## Linus’s Law
+
+> **“Given enough eyeballs, all bugs are shallow.”**
+
+**Interpretation:**  
+Open code review and a large contributor base catch defects faster. Public, transparent development yields higher quality through collective scrutiny.
+
+**Good Examples:**
+1. **Linux Kernel**: Thousands of developers and companies identify and fix bugs within days of code submissions.
+2. **Open Game Engine**: Welcomed community pull requests and bug reports; stability improved dramatically between versions.
+
+**Bad Examples:**
+1. **Closed Beta**: A select tester group missed UI freezes that only appeared under varied hardware; bugs reached full release.
+2. **FAANG Internal Tool**: Restricting repo access to one team delayed bug discovery until after customer rollout.
+
+## Moore’s Law
+
+> **“Transistor count (and hence raw computing power) doubles approximately every 18–24 months.”**
+
+**Interpretation:**  
+Rapid hardware improvements tempt developers to add features or layers rather than optimize. But reliance on ever-cheaper cycles can backfire if hardware gains slow.
+
+**Good Examples:**
+1. **Nvidia GPU Dev**: Leveraged each new GPU gen for real-time ray tracing features, pushing game visuals forward without crippled performance.
+2. **Cloud Startup**: Scaled compute-heavy AI workloads cost-effectively by shifting to next-gen instances, reducing time-to-market.
+
+**Bad Examples:**
+1. **Software Bloat**: Each release adds abstraction layers assuming Moore’s Law will cover the perf hit—eventually systems grind to a crawl.
+2. **AAA Porting**: Ported a PC engine to console without optimization, expecting console hardware to “catch up,” resulting in poor frame rates.
+
+## Wirth’s Law
+
+> **“Software gets slower faster than hardware gets faster.”**
+
+**Interpretation:**  
+Unchecked feature creep and heavy frameworks can negate Moore’s Law gains. Engineers must stay vigilant: profile, trim, and optimize critical paths.
+
+**Good Examples:**
+1. **Embedded Systems**: Team wrote performance-critical routines in C, hand-optimized inner loops, keeping firmware snappy on limited hardware.
+2. **Game Asset Pipeline**: Automated texture compression and streaming, minimizing memory footprint and load times.
+
+**Bad Examples:**
+1. **FAANG Microservices Sprawl**: Service mesh, side-cars, and proxies piled on, increasing request latency beyond hardware improvements.
+2. **Web Startup**: Adopted heavy front-end frameworks without profiling; initial page load times on mobile ballooned to 10+ seconds.
+
+## Ninety-ninety Rule
+
+> **“The first 90% of the code takes 10% of the time; the remaining 10% takes the other 90% of the time.”**
+
+**Interpretation:**  
+Early development seems fast—core features come together quickly. Polishing, edge cases, testing, and deployment often consume most of the schedule.
+
+**Good Examples:**
+1. **FAANG Release Process**: Allocated equal time for alpha, beta, and release-candidate cycles, ensuring final polish didn’t get squeezed.
+2. **AAA QA Pipeline**: Built multiple playtest phases into the calendar; final 10% of bug fixes and performance tuning had dedicated sprints.
+
+**Bad Examples:**
+1. **Startup MVP Rush**: Skipped QA at the end to hit “launch” date. Customers found critical bugs; reputation suffered.
+2. **Open Source Release**: Maintainers focused on new features, ignored final integration testing—users encountered show-stopping regressions.
+
+## Knuth’s Optimization Principle
+
+> **“Premature optimization is the root of all evil.”**
+
+**Interpretation:**  
+Write clear, correct code first. Only after profiling identifies true bottlenecks should you optimize. Otherwise you waste time on unimportant paths.
+
+**Good Examples:**
+1. **GPU Shader Team**: Profiled frame-render loop, then optimized only the hottest shader variants—gained 30% perf with minimal complexity.
+2. **Web Scale Startup**: Used APM tooling to find slow DB queries, refactored just those queries, speeding up page loads by 50%.
+
+**Bad Examples:**
+1. **AAA Engine Rewrite**: Spent months hand-tuning rendering subsystems before game mechanics were defined—ultimate game delayed.
+2. **FAANG Feature Sprint**: Developer rewrote JSON parser for tiny speed gain, introducing subtle bugs and delaying feature shipping.
+
+## Norvig’s Law
+
+> **“Any technology that surpasses 50% penetration will never double again.”**
+
+**Interpretation:**  
+Once a product, platform, or language reaches mainstream saturation, further growth slows dramatically. Recognize maturity and adjust strategy accordingly.
+
+**Good Examples:**
+1. **Search Engine Product**: At 60% market share, team pivoted to adjacent services (maps, cloud) instead of chasing further search growth.
+2. **AAA Game Engine**: Recognized core engine had peaked in adoption; focused on new middleware offerings rather than pushing new engine sales.
+
+**Bad Examples:**
+1. **Social Startup**: After reaching 55% of its target demographic, poured all resources into growth hacks that yielded diminishing returns.
+2. **GPU Architecture**: Attempted to double transistor count annually beyond physical limits, leading to skyrocketing costs and thermal issues.
+
+## Conclusion
+
+Understanding—and applying—these laws with real-world context helps you anticipate pitfalls, make informed trade-offs, and guide teams through complexity. Whether you’re in a two-person startup or a global FAANG organization, these principles will serve as your compass.
+
 ## Summary
 
 The key is to write clean, testable, functional code that evolves through small, safe increments. Every change should be driven by a test that describes the desired behavior, and the implementation should be the simplest thing that makes that test pass. When in doubt, favor simplicity and readability over cleverness.

--- a/RULES.md
+++ b/RULES.md
@@ -7,6 +7,7 @@ These rules keep development consistent across the project. The document is inte
 - Follow Test-Driven Development. Write tests before production code and keep changes small.
 - Use strict TypeScript and prefer immutable patterns.
 - When looking for solutions, consult **context7** and the guidance in **MEMORY.md**. Do not copy text from MEMORY.md into this file.
+- Review the **Software Engineering Laws** section in **MEMORY.md** for lessons that inform architectural decisions.
 
 ## Local Workflow
 


### PR DESCRIPTION
## Summary
- mention Software Engineering Laws section in RULES
- add large section on classic software engineering laws to MEMORY

## Codex CI
- `npm ci`
- `npm run build`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a8ffe9d488333ab3db8852d4728da